### PR TITLE
Add unsuccessful sign in feature test

### DIFF
--- a/spec/features/user_signin_spec.rb
+++ b/spec/features/user_signin_spec.rb
@@ -17,4 +17,15 @@ RSpec.feature "User Sign Ip", :type => :feature do
     click_on "Save Session"
     expect(page).to have_content("Logged in!")
   end
+
+  scenario "An unsuccessful sign in reloads the sign in form" do
+    User.create(name: "test_user",
+                password: "password",
+                password_confirmation: "password")
+    visit signin_path
+    fill_in "session_name", :with => "test_user"
+    fill_in "session_password", :with => "not_password"
+    click_on "Save Session"
+    expect(page).to have_content("Invalid username or password")
+  end
 end


### PR DESCRIPTION
Adding a test for an incorrect sign up.

:cactus: 
